### PR TITLE
Do not update file if content is the same

### DIFF
--- a/StubsController.php
+++ b/StubsController.php
@@ -78,6 +78,8 @@ TPL;
         $content = str_replace('{stubs}', $stubs, $this->getTemplate());
         $content = str_replace('{time}', date(DATE_ISO8601), $content);
 
-        file_put_contents($path, $content);
+        if($content!=@file_get_contents($path)) {
+            file_put_contents($path, $content);
+        }
     }
 }


### PR DESCRIPTION
The file watcher starts an infinite cycle of self-triggering. Can't find a setting in IntelliJ IDEA not to trigger the watcher upon vendor/Yii.php file change.