### PR TITLE
allow user to type in config file path/name

### DIFF
--- a/StubsController.php
+++ b/StubsController.php
@@ -52,9 +52,9 @@ TPL;
 
         $components = [];
 
-        foreach (\Yii::$app->requestedParams as $app) {
-            $configFile = $app . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'main.php';
-            if (!file_exists($configFile)) {
+        foreach (\Yii::$app->requestedParams as $configFile) {
+
+            if (!is_file($configFile)) {
                 throw new Exception('Config file doesn\'t exists: ' . $configFile);
             }
 


### PR DESCRIPTION
instead of assuming config file is config/main.php, 
allow user to type in config file path/name, such as config/web.php

use is_file() instead of file_exists(), so if user enters a directory and not a file, exception is thrown