### PR TITLE
Поддержка конфигурации компонента в виде имени класса

### DIFF
--- a/StubsController.php
+++ b/StubsController.php
@@ -79,6 +79,10 @@ TPL;
             }
 
             foreach ($config['components'] as $name => $component) {
+                if (is_string($component)) {
+                    $component = ['class' => $component];
+                }
+
                 if ($name === 'user' && isset($component['identityClass'])) {
                     $userIdentities[] = $component['identityClass'];
                 }


### PR DESCRIPTION
Добавил поддержку конфигурации компонентов в таком виде:
```
[
    'components' => [
        // register "cache" component using a class name
        'cache' => 'yii\caching\ApcCache',
    ],
]
```