### PR TITLE
Fixed: don't work with Yii2 2.0.36+

### DIFF
--- a/StubsController.php
+++ b/StubsController.php
@@ -67,7 +67,7 @@ TPL;
         $components = [];
         $userIdentities = [];
 
-        foreach (\Yii::$app->requestedParams as $configPath) {
+        foreach (array_slice(\Yii::$app->getRequest()->getParams(), 1) as $configPath) {
             if (!file_exists($configPath)) {
                 throw new Exception('Config file doesn\'t exists: ' . $configPath);
             }


### PR DESCRIPTION
`Yii::$app->requestedParams` is empty in Yii2 2.0.36+.
Replaced this code to `array_slice(\Yii::$app->getRequest()->getParams(), 1)`.